### PR TITLE
remove print statements that interfere with expected output

### DIFF
--- a/fng_api/main.py
+++ b/fng_api/main.py
@@ -62,7 +62,6 @@ def getIdentity(nameset=["gr"], country=["gr"], gender="50", minage="19", maxage
 	zip = fullAddress[2].split(" ")[2]
 
 	idx = len(soup.find_all("dd")) + 1 - 32;
-	print(idx)
 
 	phone = soup.find_all("dd")[idx].text
 	countryCode = soup.find_all("dd")[idx + 1].text
@@ -134,5 +133,3 @@ def getIdentity(nameset=["gr"], country=["gr"], gender="50", minage="19", maxage
 	
 	iden = identity(name, address, street, city, state, zip, phone, countryCode, birthday, birthdayMonth, birthdayDay, birthdayYear, age, zodiac, email, username, password, website, useragent, card, expiration, cvv2, company, occupation, height, heightcm, weight, weightkg, blood, ups, westernunion, moneygram, color, vehicle, guid)
 	return iden
-
-print(getIdentity().weight)


### PR DESCRIPTION
There were two print statements in the code which caused unexpected output on the console when using the library.
I will include an example of an app which was supposed to only output usernames of identities in a loop. Instead, you see that in the beginning the weight is posted of one identity and between every username there is a number two. This commit fixes this.
![image](https://user-images.githubusercontent.com/26165288/213172899-a2f160a4-f5ba-4b60-b6f2-db1f54dec509.png)
